### PR TITLE
Corrigir processamento de palavra e melhorar organização da classe Afd

### DIFF
--- a/include/afd.h
+++ b/include/afd.h
@@ -14,8 +14,11 @@ class Afd {
     std::set<std::string> estadosFinais;
     std::map<std::pair<std::string, char>, std::string> transicoes;
 
+    void imprimirPasso(const std::string& estado, const std::string& palavra) const;
+    void imprimirResultado(bool resultado) const;
+
    public:
-    Afd();
+    Afd() = default;
 
     std::string getAlfabeto() const;
     std::set<std::string> getEstados() const;

--- a/src/afd.cpp
+++ b/src/afd.cpp
@@ -1,5 +1,5 @@
 #include "../include/afd.h"
-#include <algorithm>
+
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -8,36 +8,40 @@
 #include <string>
 #include <utility>
 
+void Afd::imprimirPasso(const std::string& estado, const std::string& palavra) const {
+    std::cout << '[' << estado << ']' << palavra << "\n";
+}
+
+void Afd::imprimirResultado(bool resultado) const {
+    std::cout << (resultado ? "ACEITA" : "REJEITA") << '\n';
+}
+
 void Afd::processarPalavra(const std::string& palavra) const {
     std::string estadoAtual = this->estadoInicial;
 
-    for (int i = 0; i <= palavra.length(); i++) {
-        // Se for símbolo vazio, subpalavra armazena "@"
-        std::string subpalavra = (i < palavra.length()) ? palavra.substr(i) : "@";
-
-        // Imprime o estado atual e o restante da palavra a ser processada
-        std::cout << '[' << estadoAtual << ']' << subpalavra << "\n";
-
-        if (i < palavra.length()) {
-            // Verifica se há uma transição válida, dado o estado e o símbolo atuais
-            auto chave = std::make_pair(estadoAtual, palavra[i]);
-            if (transicoes.find(chave) == transicoes.end()) {
-                std::cout << "REJEITA\n";
-                break;
-            }
-
-            estadoAtual = transicoes.at(chave);
-        }
+    // Caso especial: palavra vazia
+    if (palavra.empty()) {
+        imprimirPasso(estadoAtual, "@");
+        imprimirResultado(estadosFinais.count(estadoAtual) > 0);
+        return;
     }
 
-    // Verifica se o estado final encontrado está no conjunto de aceitação
-    if (estadosFinais.count(estadoAtual) > 0)
-        std::cout << "ACEITA\n";
-    else
-        std::cout << "REJEITA\n";
+    for (size_t i = 0; i < palavra.length(); i++) {
+        imprimirPasso(estadoAtual, palavra.substr(i));
+
+        // Verifica se há uma transição válida, dado o estado e o símbolo atuais
+        auto chave = std::make_pair(estadoAtual, palavra[i]);
+        if (transicoes.find(chave) == transicoes.end()) {
+            imprimirResultado(false);
+            return;
+        }
+        estadoAtual = transicoes.at(chave);
+    }
+
+    imprimirPasso(estadoAtual, "");
+    imprimirResultado(estadosFinais.count(estadoAtual) > 0);
 }
 
-// metodo para ler um automato finito deterministico de um arquivo texto
 void Afd::lerDeArquivo(const std::string& nomeArquivo) {
     std::ifstream arquivo(nomeArquivo);
 


### PR DESCRIPTION
## O que foi feito
- Corrigida a lógica da função `processarPalavra`, que não tratava corretamente alguns casos e imprimia resultados repetidos.
- Extraídas funções auxiliares `imprimirPasso` e `imprimirResultado` para evitar repetição de código.
- Tornado explícito o construtor padrão da classe Afd com `Afd() = default`.
- Removido inclusão desnecessária em `afd.cpp`.
- Removido comentário da função `lerDeArquivo`.

## Por que foi feito
As alterações melhoram a clareza do código, corrigem um comportamento incorreto na aceitação de palavras e facilitam a manutenção futura ao modularizar a impressão.
