### PR TITLE
Adicionar getters, setters e constructor. Adicionar verificação em leitura de arquivo

### DIFF
--- a/include/afd.h
+++ b/include/afd.h
@@ -32,7 +32,7 @@ class Afd {
     void setEstadosFinais(const std::set<std::string>& estadosFinais);
     void setTransicoes(const std::map<std::pair<std::string, char>, std::string>& transicoes);
 
-    void lerDeArquivo(const std::string& nomeArquivo);
+    bool lerDeArquivo(const std::string& nomeArquivo);
     void processarPalavra(const std::string& palavra) const;
     class Gr converterParaGR() const;
 };

--- a/include/afd.h
+++ b/include/afd.h
@@ -19,6 +19,7 @@ class Afd {
 
    public:
     Afd() = default;
+    Afd(const std::string& nomeArquivo);
 
     std::string getAlfabeto() const;
     std::set<std::string> getEstados() const;

--- a/include/gr.h
+++ b/include/gr.h
@@ -13,7 +13,7 @@ class Gr {
     std::map<std::string, std::set<std::string>> producoes;
 
    public:
-    Gr();
+    Gr() = default;
 
     std::set<std::string> getNaoTerminais() const;
     std::string getTerminais() const;

--- a/src/afd.cpp
+++ b/src/afd.cpp
@@ -9,6 +9,12 @@
 #include <string>
 #include <utility>
 
+Afd::Afd(const std::string& nomeArquivo) {
+    if (!lerDeArquivo(nomeArquivo)) {
+        throw std::ios_base::failure("Erro ao abrir o arquivo \"" + nomeArquivo + "\"");
+    }
+}
+
 void Afd::imprimirPasso(const std::string& estado, const std::string& palavra) const {
     std::cout << '[' << estado << ']' << palavra << "\n";
 }

--- a/src/afd.cpp
+++ b/src/afd.cpp
@@ -43,8 +43,11 @@ void Afd::processarPalavra(const std::string& palavra) const {
     imprimirResultado(estadosFinais.count(estadoAtual) > 0);
 }
 
-void Afd::lerDeArquivo(const std::string& nomeArquivo) {
+bool Afd::lerDeArquivo(const std::string& nomeArquivo) {
     std::ifstream arquivo(nomeArquivo);
+    if (!arquivo) {
+        return false;
+    }
 
     std::string linha;
     int linhaAtual = 0;
@@ -100,6 +103,8 @@ void Afd::lerDeArquivo(const std::string& nomeArquivo) {
         }
     }
     estadoInicial = "q0";
+
+    return true;
 }
 
 Gr Afd::converterParaGR() const {

--- a/src/afd.cpp
+++ b/src/afd.cpp
@@ -101,6 +101,7 @@ void Afd::lerDeArquivo(const std::string& nomeArquivo) {
     }
     estadoInicial = "q0";
 }
+
 Gr Afd::converterParaGR() const {
     Gr gramatica;
 
@@ -138,4 +139,44 @@ Gr Afd::converterParaGR() const {
 
     gramatica.setProducoes(producoes);
     return gramatica;
+}
+
+std::string Afd::getAlfabeto() const {
+    return alfabeto;
+}
+
+std::set<std::string> Afd::getEstados() const {
+    return estados;
+}
+
+std::string Afd::getEstadoInicial() const {
+    return estadoInicial;
+}
+
+std::set<std::string> Afd::getEstadosFinais() const {
+    return estadosFinais;
+}
+
+std::map<std::pair<std::string, char>, std::string> Afd::getTransicoes() const {
+    return transicoes;
+}
+
+void Afd::setAlfabeto(const std::string& alfabeto) {
+    this->alfabeto = alfabeto;
+}
+
+void Afd::setEstados(const std::set<std::string>& estados) {
+    this->estados = estados;
+}
+
+void Afd::setEstadoInicial(const std::string& estadoInicial) {
+    this->estadoInicial = estadoInicial;
+}
+
+void Afd::setEstadosFinais(const std::set<std::string>& estadosFinais) {
+    this->estadosFinais = estadosFinais;
+}
+
+void Afd::setTransicoes(const std::map<std::pair<std::string, char>, std::string>& transicoes) {
+    this->transicoes = transicoes;
 }

--- a/src/gr.cpp
+++ b/src/gr.cpp
@@ -1,5 +1,4 @@
 #include "../include/gr.h"
-#include "../include/afd.h"
 
 #include <iostream>
 #include <map>
@@ -40,4 +39,36 @@ void Gr::imprimirGR() const {
         }
         std::cout << "\n";
     }
+}
+
+std::set<std::string> Gr::getNaoTerminais() const {
+    return naoTerminais;
+}
+
+std::string Gr::getTerminais() const {
+    return terminais;
+}
+
+std::string Gr::getSimboloInicial() const {
+    return simboloInicial;
+}
+
+std::map<std::string, std::set<std::string>> Gr::getProducoes() const {
+    return producoes;
+}
+
+void Gr::setNaoTerminais(const std::set<std::string>& naoTerminais) {
+    this->naoTerminais = naoTerminais;
+}
+
+void Gr::setTerminais(const std::string& terminais) {
+    this->terminais = terminais;
+}
+
+void Gr::setSimboloInicial(const std::string& simboloInicial) {
+    this->simboloInicial = simboloInicial;
+}
+
+void Gr::setProducoes(const std::map<std::string, std::set<std::string>>& producoes) {
+    this->producoes = producoes;
 }


### PR DESCRIPTION
## O quê:
- Adiciona a implementação dos getters e setters das classes `Afd` e `Gr`
- Adiciona o construtor padrão da classe `Gr`
- Adiciona o construtor da classe `Afd` que realiza leitura de arquivo
- Altera retorno da função `lerDeArquivo` de `void` para `bool`
- Adiciona verificação se o arquivo pode ser aberto dentro de `lerDeArquivo`

## Como:
- A função `lerDeArquivo` agora retorna false caso o arquivo não possa ser aberto.
- O novo construtor de `Afd` recebe uma `std::string` com o nome do arquivo que define o autômato. Caso o arquivo não possa ser lido, uma exceção do tipo `std::runtime_error` é lançada.

## Notas:
- A alteração permite maior robustez na leitura do AFD, facilitando o tratamento de erros por parte do código cliente.
- Não houve mudanças na assinatura dos getters/setters já presentes nos headers.

## Checklist:
- [x] Código segue padrão de estilo definido (clang-format)
- [x] Verificado funcionamento local (build, execução manual do menu)
- [x] Tratamento de erro verificado com entrada de arquivo inexistente